### PR TITLE
Fix several Windows issues

### DIFF
--- a/src/MarlinSimulator/RawSocketSerial.h
+++ b/src/MarlinSimulator/RawSocketSerial.h
@@ -37,6 +37,7 @@ public:
     }
     start_listen(ip);
     server_thread = std::thread(&RawSocketSerial::execute, this);
+    thread_active = true;
   }
 
   void stop() {
@@ -178,7 +179,7 @@ public:
   void write(const char* str)                    { while (*str) tx_buffer.write(*str++); }
   void write(const uint8_t* buffer, size_t size) { tx_buffer.write((uint8_t *)buffer, size); }
 
-  bool thread_active = true;
+  bool thread_active = false;
   ServerInfo server{};
   uint8_t receive_buffer[ServerInfo::max_packet_size];
   uint8_t transmit_buffer[ServerInfo::max_packet_size];

--- a/src/MarlinSimulator/main.cpp
+++ b/src/MarlinSimulator/main.cpp
@@ -60,10 +60,13 @@ void simulation_main() {
 
 // Main code
 int main(int, char**) {
+
+  // Listen before starting simulator loop to avoid
+  // thread synchronization issues if listen_on_port fails
+  net_serial.listen_on_port(8099);
+
   Application app;
   std::thread simulation_loop(simulation_main);
-
-  net_serial.listen_on_port(8099);
 
   while (app.active) {
     app.update();

--- a/src/MarlinSimulator/main.cpp
+++ b/src/MarlinSimulator/main.cpp
@@ -60,6 +60,8 @@ void simulation_main() {
 
 // Main code
 int main(int, char**) {
+  SDL_Init(0);
+  SDLNet_Init();
 
   // Listen before starting simulator loop to avoid
   // thread synchronization issues if listen_on_port fails
@@ -78,6 +80,9 @@ int main(int, char**) {
   Kernel::quit_requested = true;
   simulation_loop.join();
   net_serial.stop();
+
+  SDLNet_Quit();
+  SDL_Quit();
 
   return 0;
 }


### PR DESCRIPTION
Resolves several issues launching the simulator on Windows.

1. Initialize SDL and SDLInit, allowing `net_serial.listen_on_port` to succeed.
2. Listen on port prior to starting execution threads, to avoid segmentation faults in listen_on_port fails.
3. Initialize RawSocketSerial::thread_active to false, to avoid trying to stop unstarted threads on error.

With these changes (along with several changes in Marlin) I am able to successfully launch the simulator on Windows.