### PR TITLE
Fix file streaming on Windows

### DIFF
--- a/src/MarlinSimulator/user_interface.h
+++ b/src/MarlinSimulator/user_interface.h
@@ -271,10 +271,11 @@ struct SerialMonitor : public UiWindow {
       // File read into serial port
     if (input_file.is_open() && serial_stream.receive_buffer.free() && streaming) {
       uint8_t buffer[HalSerial::receive_buffer_size]{};
-      auto count = input_file.readsome((char*)buffer, serial_stream.receive_buffer.free());
-      serial_stream.receive_buffer.write(buffer, count);
-      stream_sent += count;
-      if (count == 0) {
+      size_t read_size = std::min(serial_stream.receive_buffer.free(), stream_total - stream_sent);
+      input_file.read((char*)buffer, read_size);
+      serial_stream.receive_buffer.write(buffer, read_size);
+      stream_sent += read_size;
+      if (stream_sent >= stream_total) {
         input_file.close();
         streaming = false;
         stream_total = 0;


### PR DESCRIPTION
On Windows the `readsome` command never actually reads bytes from disk. It always returns zero bytes.

Rework the streaming operation to use `read` instead of `readsome`.

I have been using this on Windows, although I have note tested it with large files or on Linux.