### PR TITLE
Add runtime switching of pin logging, with export to VCD file

### DIFF
--- a/library.json
+++ b/library.json
@@ -20,7 +20,8 @@
   "dependencies":
   {
     "imgui": "https://github.com/p3p/imgui.git#pio_docking",
-    "implot": "https://github.com/p3p/implot.git#pio_master"
+    "implot": "https://github.com/p3p/implot.git#pio_master",
+    "vcd-writer": "https://github.com/favorart/vcd-writer"
   },
   "build": {
     "libLDFMode": "deep"

--- a/src/MarlinSimulator/application.cpp
+++ b/src/MarlinSimulator/application.cpp
@@ -72,67 +72,84 @@ Application::Application() {
   });
 
   user_interface.addElement<UiWindow>("Signal Analyser", [this](UiWindow* window){
-    struct ScrollingData {
-      int MaxSize;
-      int Offset;
-      ImVector<ImPlotPoint> Data;
-      ScrollingData() {
-          MaxSize = 100000;
-          Offset  = 0;
-          Data.reserve(MaxSize);
+    if (!Gpio::isLoggingEnabled()) {
+      if (ImGui::Button("Enable Pin Logging")) {
+        Gpio::setLoggingEnabled(true);
       }
-      void AddPoint(double x, double y) {
-          if (Data.size() < MaxSize)
-              Data.push_back(ImPlotPoint(x,y));
-          else {
-              Data[Offset] = ImPlotPoint(x,y);
-              Offset =  (Offset + 1) % MaxSize;
-          }
-      }
-      void Erase() {
-          if (Data.size() > 0) {
-              Data.shrink(0);
-              Offset  = 0;
-          }
-      }
-    };
-
-    static pin_type monitor_pin = X_STEP_PIN;
-    static const char* label = "Select Pin";
-    static char* active_label = (char *)label;
-    if(ImGui::BeginCombo("##Select Pin", active_label)) {
-      for (auto p : pin_array) {
-        if (ImGui::Selectable(p.name, p.pin == monitor_pin)) {
-          monitor_pin = p.pin;
-          active_label = (char *)p.name;
-        }
-        if (p.pin == monitor_pin) ImGui::SetItemDefaultFocus();
-      }
-      ImGui::EndCombo();
     }
-
-    if (Gpio::pin_map[monitor_pin].event_log.size()) {
-      ScrollingData sdata;
-
-      pin_log_data last{};
-      for (auto v : Gpio::pin_map[monitor_pin].event_log) {
-        if (last.timestamp) sdata.AddPoint(v.timestamp, last.value);
-        sdata.AddPoint(v.timestamp, v.value);
-        last = v;
+    else {
+      if (ImGui::Button("Disable Pin Logging")) {
+        Gpio::setLoggingEnabled(false);
       }
-      sdata.AddPoint(Kernel::SimulationRuntime::nanos(),  last.value);
+      ImGui::SameLine();
+      if (ImGui::Button("Reset logs")) {
+        Gpio::resetLogs();
+      }
 
-      static float window = 10000000000.0f;
-      ImGui::SliderFloat("Window", &window, 10.f, 100000000000.f,"%.0f ns");
-      static float offset = 0.0f;
-      ImGui::SliderFloat("X offset", &offset, 0.f, 10000000000.f,"%.0f ns");
-      // ImPlot::SetNextPlotLimitsX(Kernel::SimulationRuntime::nanos() - window - offset, Kernel::SimulationRuntime::nanos() - offset, ImGuiCond_Always);
-      // ImPlot::SetNextPlotLimitsY(0.0f, 1.2f, ImGuiCond_Always);
-      // static int rt_axis = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_LockMin;
-      // if (ImPlot::BeginPlot("##Scrolling", "Time (ns)", NULL, ImVec2(-1,150), ImPlotAxisFlags_NoTickLabels | ImPlotFlags_Query, rt_axis, rt_axis)) {
-      //   ImPlot::PlotLine("pin", &sdata.Data[0].x, &sdata.Data[0].y, sdata.Data.size(), sdata.Offset, sizeof(ImPlotPoint));
-      //   ImPlot::EndPlot();
-      // }
+      struct ScrollingData {
+        int MaxSize;
+        int Offset;
+        ImVector<ImPlotPoint> Data;
+        ScrollingData() {
+            MaxSize = 100000;
+            Offset  = 0;
+            Data.reserve(MaxSize);
+        }
+        void AddPoint(double x, double y) {
+            if (Data.size() < MaxSize)
+                Data.push_back(ImPlotPoint(x,y));
+            else {
+                Data[Offset] = ImPlotPoint(x,y);
+                Offset =  (Offset + 1) % MaxSize;
+            }
+        }
+        void Erase() {
+            if (Data.size() > 0) {
+                Data.shrink(0);
+                Offset  = 0;
+            }
+        }
+      };
+
+      static pin_type monitor_pin = X_STEP_PIN;
+      static const char* label = "Select Pin";
+      static char* active_label = (char *)label;
+      if(ImGui::BeginCombo("##Select Pin", active_label)) {
+        for (auto p : pin_array) {
+          if (ImGui::Selectable(p.name, p.pin == monitor_pin)) {
+            monitor_pin = p.pin;
+            active_label = (char *)p.name;
+          }
+          if (p.pin == monitor_pin) ImGui::SetItemDefaultFocus();
+        }
+        ImGui::EndCombo();
+      }
+
+      if (Gpio::pin_map[monitor_pin].event_log.size()) {
+        ScrollingData sdata;
+
+        pin_log_data last{};
+        for (auto v : Gpio::pin_map[monitor_pin].event_log) {
+          if (last.timestamp) sdata.AddPoint(v.timestamp, last.value);
+          sdata.AddPoint(v.timestamp, v.value);
+          last = v;
+        }
+        sdata.AddPoint(Kernel::SimulationRuntime::nanos(),  last.value);
+
+        static float window = 10000000000.0f;
+        ImGui::SliderFloat("Window", &window, 10.f, 100000000000.f,"%.0f ns", ImGuiSliderFlags_Logarithmic);
+        static float offset = 0.0f;
+        ImGui::SliderFloat("X offset", &offset, 0.f, 10000000000.f,"%.0f ns");
+        ImGui::SliderFloat("X offset", &offset, 0.f, 100000000000.f,"%.0f ns");
+        if (!ImPlot::GetCurrentContext()) ImPlot::CreateContext();
+        ImPlot::SetNextPlotLimitsX(Kernel::SimulationRuntime::nanos() - window - offset, Kernel::SimulationRuntime::nanos() - offset, ImGuiCond_Always);
+        ImPlot::SetNextPlotLimitsY(0.0f, 1.2f, ImGuiCond_Always);
+        static int rt_axis = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_LockMin;
+        if (ImPlot::BeginPlot("##Scrolling", "Time (ns)", NULL, ImVec2(-1,150), ImPlotAxisFlags_NoTickLabels | ImPlotFlags_Query, rt_axis, rt_axis)) {
+          ImPlot::PlotLine("pin", &sdata.Data[0].x, &sdata.Data[0].y, sdata.Data.size(), sdata.Offset, sizeof(ImPlotPoint));
+          ImPlot::EndPlot();
+        }
+      }
     }
   });
 

--- a/src/MarlinSimulator/application.cpp
+++ b/src/MarlinSimulator/application.cpp
@@ -199,7 +199,7 @@ Application::Application() {
               std::string pin_name(pin.name);
               bool regex_match = strlen(export_regex) == 0 || std::regex_search(pin_name, expression);
               auto scope = pin_name.substr(0, pin_name.find_first_of('_'));
-              if (pin.is_digital && regex_match) // && Gpio::pin_map[pin.pin].event_log.size() > 1) // Questionable attempt to filter output for inactive lines
+              if (pin.is_digital && regex_match)
                 pin_to_var_map[pin.pin] = writer.register_var(scope, pin_name, VariableType::wire, 1);
             }
 

--- a/src/MarlinSimulator/hardware/Gpio.cpp
+++ b/src/MarlinSimulator/hardware/Gpio.cpp
@@ -1,4 +1,4 @@
 #include "Gpio.h"
 
 pin_data Gpio::pin_map[Gpio::pin_count] = {};
-
+bool Gpio::logging_enabled = false;


### PR DESCRIPTION
Existing pin-logging code was commented out. I've made this selectable at run-time with the ability to export logs.

### Added capabilities
1. Runtime enable/disable/reset of logging
![image](https://user-images.githubusercontent.com/20053467/144725282-15315d57-ab93-4bb4-a4a4-fbe5875b8930.png)
![image](https://user-images.githubusercontent.com/20053467/144725290-f79767d4-1bfc-428b-bab1-4d832df03f16.png)

2. Export of a single pin or all pins matching a regex to VCD file format which can be imported into PulseView.
![image](https://user-images.githubusercontent.com/20053467/144725303-60ffa760-fa7c-42d8-9ee9-7b0c27a1bfbe.png)

### Sample after importing pins matching `^X_` into PulseView:
![image](https://user-images.githubusercontent.com/20053467/144725316-1628eb8e-035f-4e98-a521-7bfd13164ab2.png)

### Known Issues
1. Changing logging state or resetting logs while not paused can crash
  There is nothing protecting access to the logging data structures, so if a pin state is changed while the log is being cleared errors can occur.

2. The file selection dialog is not very good
  I reused the file dialog from the file streaming option. It doesn't actually guarantee a ".vcd" file extension, and could use improvement.