### PR TITLE
MarlinHAL 2.0.9.3

### DIFF
--- a/src/MarlinSimulator/marlin_hal_impl/HAL.cpp
+++ b/src/MarlinSimulator/marlin_hal_impl/HAL.cpp
@@ -48,35 +48,35 @@ int freeMemory() {
 // ADC
 // ------------------------
 
-void HAL_adc_init() {
+void MarlinHAL::adc_init() {
 
 }
 
-void HAL_adc_enable_channel(const uint8_t ch) {
+void MarlinHAL::adc_enable(const uint8_t ch) {
 
 }
 
-uint8_t active_ch = 0;
-void HAL_adc_start_conversion(const uint8_t ch) {
+uint8_t MarlinHAL::active_ch = 0;
+void MarlinHAL::adc_start(const uint8_t ch) {
   active_ch = ch;
 }
 
-bool HAL_adc_finished() {
+bool MarlinHAL::adc_ready() {
   return true;
 }
 
-uint16_t HAL_adc_get_result() {
+uint16_t MarlinHAL::adc_value() {
   pin_t pin = analogInputToDigitalPin(active_ch);
   if (!VALID_PIN(pin)) return 0;
   uint16_t data = ((Gpio::get(pin) >> 2) & 0x3FF);
   return data;    // return 10bit value as Marlin expects
 }
 
-void HAL_pwm_init() {
+void MarlinHAL::pwm_init() {
 
 }
 
-void HAL_reboot() { /* Reset the application state and GPIO */ }
+void MarlinHAL::reboot() { /* Reset the application state and GPIO */ }
 
 // Maple Compatibility
 volatile uint32_t systick_uptime_millis = 0;


### PR DESCRIPTION
Updated API for HALs proposed for Marlin 2.0.9.3. A new version tag – or branch – will be required for the benefit of `ini/native.ini`. Or, we could host a fork of `MarlinSimUI` under `MarlinFirmware` … if that's easier to manage.

See MarlinFirmware/Marlin#23295