### PR TITLE
Compile error with std::move()

### DIFF
--- a/src/MarlinSimulator/application.cpp
+++ b/src/MarlinSimulator/application.cpp
@@ -178,7 +178,7 @@ Application::Application() {
           using namespace vcd;
 
           HeadPtr head = makeVCDHeader(static_cast<TimeScale>(50), TimeScaleUnit::ns, utils::now());
-          VCDWriter writer{image_filename, std::move(head)};
+          VCDWriter writer{image_filename, head};
 
           if (export_single_pin) {
             std::string pin_name(active_label);


### PR DESCRIPTION
```CPP
.pio/libdeps/simulator_linux_debug/MarlinSimUI/src/MarlinSimulator/application.cpp: In lambda function:
.pio/libdeps/simulator_linux_debug/MarlinSimUI/src/MarlinSimulator/application.cpp:181:53: error: cannot bind non-const lvalue reference of type ‘vcd::HeadPtr&’ {aka ‘std::unique_ptr<vcd::VCDHeader, vcd::VCDHeaderDeleter>&’} to an rvalue of type ‘std::remove_reference<std::unique_ptr<vcd::VCDHeader, vcd::VCDHeaderDeleter>&>::type’ {aka ‘std::unique_ptr<vcd::VCDHeader, vcd::VCDHeaderDeleter>’}
  181 |           VCDWriter writer{image_filename, std::move(head)};
```
I'm not sure this is correct fix, but seems to work