### PR TITLE
force optimization level 0 for Heater::interrupt

### DIFF
--- a/src/MarlinSimulator/hardware/Heater.cpp
+++ b/src/MarlinSimulator/hardware/Heater.cpp
@@ -52,6 +52,7 @@ void Heater::update() {
 void Heater::ui_widget() {
   ImGui::Text("Temperature: %f", hotend_temperature);
 }
+
 #pragma GCC push_options
 #pragma GCC optimize ("O0")
 void Heater::interrupt(GpioEvent& ev) {

--- a/src/MarlinSimulator/hardware/Heater.cpp
+++ b/src/MarlinSimulator/hardware/Heater.cpp
@@ -52,7 +52,8 @@ void Heater::update() {
 void Heater::ui_widget() {
   ImGui::Text("Temperature: %f", hotend_temperature);
 }
-
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
 void Heater::interrupt(GpioEvent& ev) {
   // always update the temperature
   double time_delta = Kernel::TimeControl::ticksToNanos(ev.timestamp - pwm_last_update) / (double)Kernel::TimeControl::ONE_BILLION;
@@ -75,3 +76,4 @@ void Heater::interrupt(GpioEvent& ev) {
     Gpio::set_pin_value(adc_pin, adc_reading);
   }
 }
+#pragma GCC pop_options


### PR DESCRIPTION
This seems to fix the issue with heaters not working at all

Please confirm

Simply compile Marlin bugfix in simulator mode apply this patch and rebuild. In the virtual machine a M104 S200 via serial console.
 