### PR TITLE
Refactor SPI to allow for DMA simulation

### DIFF
--- a/src/MarlinSimulator/hardware/Gpio.h
+++ b/src/MarlinSimulator/hardware/Gpio.h
@@ -160,6 +160,20 @@ public:
     return pin_map[pin].dir;
   }
 
+  static void write(const pin_type pin, const uint16_t value) {
+    if (!valid_pin(pin)) return;
+    pin_map[pin].value = value;
+    GpioEvent evt(Kernel::TimeControl::getTicks(), pin, GpioEvent::SET_VALUE);
+    for (auto callback : pin_map[pin].callbacks) callback(evt);
+  }
+
+  static uint16_t read(const pin_type pin) {
+    if (!valid_pin(pin)) return 0;
+    GpioEvent evt(Kernel::TimeControl::getTicks(), pin, GpioEvent::GET_VALUE);
+    for (auto callback : pin_map[pin].callbacks) callback(evt);
+    return pin_map[pin].value;
+  }
+
   template<class... Args>
   static bool attach(const pin_type pin, Args... args) {
     if (!valid_pin(pin)) return false;

--- a/src/MarlinSimulator/hardware/SDCard.h
+++ b/src/MarlinSimulator/hardware/SDCard.h
@@ -21,7 +21,7 @@
 
 class SDCard: public SPISlavePeripheral {
 public:
-  SDCard(pin_type clk, pin_type mosi, pin_type miso, pin_type cs, pin_type sd_detect = -1, bool sd_detect_state = true) : SPISlavePeripheral(clk, mosi, miso, cs), sd_detect(sd_detect), sd_detect_state(sd_detect_state), image_filename(SD_SIMULATOR_FAT_IMAGE) {
+  SDCard(SpiBus& spi_bus, pin_type cs, pin_type sd_detect = -1, bool sd_detect_state = true) : SPISlavePeripheral(spi_bus, cs), sd_detect(sd_detect), sd_detect_state(sd_detect_state), image_filename(SD_SIMULATOR_FAT_IMAGE) {
     if (Gpio::valid_pin(sd_detect)) {
       Gpio::attach(sd_detect, [this](GpioEvent& event){ this->interrupt(event); });
     }

--- a/src/MarlinSimulator/hardware/SPISlavePeripheral.h
+++ b/src/MarlinSimulator/hardware/SPISlavePeripheral.h
@@ -2,24 +2,23 @@
 
 #include "../virtual_printer.h"
 #include "Gpio.h"
+#include "bus/spi.h"
 
 /**
  * Class to Easily Handle SPI Slave communication
  */
 class SPISlavePeripheral : public VirtualPrinter::Component {
 public:
-  SPISlavePeripheral(pin_type clk, pin_type miso, pin_type mosi, pin_type cs, uint8_t CPOL = 0, uint8_t CPHA = 0);
+  SPISlavePeripheral(SpiBus &spi_bus, pin_type cs);
   virtual ~SPISlavePeripheral();
 
   // Callbacks
   virtual void onBeginTransaction();
   virtual void onEndTransaction();
 
-  virtual void onBitReceived(uint8_t _bit);
   virtual void onByteReceived(uint8_t _byte);
   virtual void onRequestedDataReceived(uint8_t token, uint8_t* _data, size_t count);
 
-  virtual void onBitSent(uint8_t _bit);
   virtual void onByteSent(uint8_t _byte);
   virtual void onResponseSent();
 
@@ -34,18 +33,15 @@ public:
   void clearCurrentToken() { currentToken = 0xFF; }
 
 protected:
-  void transmitCurrentBit();
-  void spiInterrupt(GpioEvent& ev);
-
-  pin_type clk_pin, miso_pin, mosi_pin, cs_pin;
-  uint8_t CPOL, CPHA;
+  void interrupt(GpioEvent& ev);
+  void interrupt(SpiEvent& ev);
+  pin_type cs_pin;
 
 private:
   uint8_t incoming_byte = 0;
-  uint8_t incoming_bit_count = 0;
   uint8_t incoming_byte_count = 0;
   uint8_t outgoing_byte = 0xFF;
-  uint8_t outgoing_bit_count = 0;
+
   uint8_t *responseData = nullptr;
   size_t responseDataSize = 0;
   bool insideTransaction = false;
@@ -54,4 +50,5 @@ private:
   uint8_t *requestedData = nullptr;
   size_t requestedDataSize = 0;
   size_t requestedDataIndex = 0;
+  SpiBus &spi_bus;
 };

--- a/src/MarlinSimulator/hardware/ST7796Device.h
+++ b/src/MarlinSimulator/hardware/ST7796Device.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <deque>
 #include "Gpio.h"
+#include "bus/spi.h"
 
 #include "SPISlavePeripheral.h"
 #include "XPT2046Device.h"
@@ -30,7 +31,7 @@ public:
     std::vector<uint8_t> data;
   };
 
-  ST7796Device(pin_type clk, pin_type miso, pin_type mosi, pin_type tft_cs, pin_type touch_cs, pin_type dc, pin_type beeper, pin_type enc1, pin_type enc2, pin_type enc_but, pin_type back, pin_type kill);
+  ST7796Device(SpiBus& spi_bus, pin_type tft_cs, SpiBus& touch_spi_bus, pin_type touch_cs, pin_type dc, pin_type beeper, pin_type enc1, pin_type enc2, pin_type enc_but, pin_type back, pin_type kill);
   virtual ~ST7796Device();
   void process_command(Command cmd);
   void update();

--- a/src/MarlinSimulator/hardware/W25QxxDevice.cpp
+++ b/src/MarlinSimulator/hardware/W25QxxDevice.cpp
@@ -15,10 +15,7 @@ void W25QxxDevice::onByteReceived(uint8_t _byte) {
     case W25X_WriteEnable:
       break;
     case W25X_ReadStatusReg:
-      fp = fopen(SPI_FLASH_IMAGE, "wb+");
-      fwrite(data, 1, flash_size, fp);
-      fclose(fp);
-      fp = nullptr;
+      fflush(fp);
       setResponse(0);
       break;
     default:
@@ -37,22 +34,28 @@ void W25QxxDevice::onRequestedDataReceived(uint8_t token, uint8_t* _data, size_t
     case W25X_PageProgram:
       // receivind data to write!
       if (currentAddress > -1) {
-        for(size_t i = 0; i < count; i++) data[i + currentAddress] = _data[i];
+        memcpy(data + currentAddress, _data, count);
+        fwrite(_data, 1, count, fp);
         currentAddress = -1;
       }
       else {
         currentAddress = (_data[0] << 16) | (_data[1] << 8) | _data[2];
+        fseek(fp, currentAddress, SEEK_SET);
         setRequestedDataSize(W25X_PageProgram, SPI_FLASH_PerWritePageSize);
       }
       break;
     case W25X_SectorErase:
       currentAddress = (_data[0] << 16) | (_data[1] << 8) | _data[2];
       memset(data + currentAddress, 0xFF, SPI_FLASH_SectorSize);
+      fseek(fp, currentAddress, SEEK_SET);
+      fwrite(data + currentAddress, 1, SPI_FLASH_SectorSize, fp);
       currentAddress = -1;
       break;
     case W25X_BlockErase:
       currentAddress = (_data[0] << 16) | (_data[1] << 8) | _data[2];
       memset(data + currentAddress, 0xFF, 65536); //64kb
+      fseek(fp, currentAddress, SEEK_SET);
+      fwrite(data + currentAddress, 1, 65536, fp);
       currentAddress = -1;
       break;
     default:

--- a/src/MarlinSimulator/hardware/W25QxxDevice.h
+++ b/src/MarlinSimulator/hardware/W25QxxDevice.h
@@ -14,7 +14,7 @@
 
 class W25QxxDevice: public SPISlavePeripheral {
 public:
-  W25QxxDevice(pin_type clk, pin_type mosi, pin_type miso, pin_type cs, size_t flash_size) : SPISlavePeripheral(clk, mosi, miso, cs), flash_size(flash_size) {
+  W25QxxDevice(SpiBus& spi_bus, pin_type cs, size_t flash_size) : SPISlavePeripheral(spi_bus, cs), flash_size(flash_size) {
     // read current data
     data = new uint8_t[flash_size];
     memset(data, 0xFF, flash_size);
@@ -25,9 +25,9 @@ public:
       assert(fp);
       fwrite(data, 1, flash_size, fp);
     } else fread(data, 1, flash_size, fp);
-    fclose(fp);
   }
   virtual ~W25QxxDevice() {
+    fclose(fp);
     delete[] data;
   };
 

--- a/src/MarlinSimulator/hardware/XPT2046Device.h
+++ b/src/MarlinSimulator/hardware/XPT2046Device.h
@@ -9,7 +9,7 @@
 
 class XPT2046Device: public SPISlavePeripheral {
 public:
-  XPT2046Device(pin_type clk, pin_type mosi, pin_type miso, pin_type cs) : SPISlavePeripheral(clk, mosi, miso, cs) {}
+  XPT2046Device(SpiBus& spi_bus, pin_type cs) : SPISlavePeripheral(spi_bus, cs) {}
   virtual ~XPT2046Device() {};
 
   void update() {}

--- a/src/MarlinSimulator/hardware/bus/buses.cpp
+++ b/src/MarlinSimulator/hardware/bus/buses.cpp
@@ -1,0 +1,11 @@
+#include "spi.h"
+
+SpiBus SpiBus0;
+SpiBus SpiBus1;
+SpiBus SpiBus2;
+SpiBus SpiBus3;
+
+template<> SpiBus& spi_bus_by_pins<50, 52, 51>() { return SpiBus0; }
+template<> SpiBus& spi_bus_by_pins<100, 101, 102>() { return SpiBus1; }
+template<> SpiBus& spi_bus_by_pins<110, 111, 112>() { return SpiBus2; }
+template<> SpiBus& spi_bus_by_pins<120, 121, 122>() { return SpiBus3; }

--- a/src/MarlinSimulator/hardware/bus/i2c.h
+++ b/src/MarlinSimulator/hardware/bus/i2c.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class I2cBus {
+public:
+  I2cBus() {};
+  ~I2cBus() = default;
+};

--- a/src/MarlinSimulator/hardware/bus/serial.h
+++ b/src/MarlinSimulator/hardware/bus/serial.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class SerialBus {
+public:
+  SerialBus() {};
+  ~SerialBus() = default;
+};

--- a/src/MarlinSimulator/hardware/bus/spi.h
+++ b/src/MarlinSimulator/hardware/bus/spi.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <functional>
+
+#include "../Gpio.h"
+
+struct SpiEvent {
+  uint8_t *write_from, *read_into;
+  size_t length;
+  bool source_increment = true;
+  uint8_t source_format = 1;
+};
+
+class SpiBus {
+public:
+  SpiBus() {}
+  ~SpiBus() = default;
+  SpiBus(const SpiBus&) = delete;
+
+  void write(uint8_t value) {
+    auto evt = SpiEvent{&value, nullptr, 1};
+    for (auto callback : callbacks) callback(evt);
+  }
+
+  uint8_t read() {
+    uint8_t value;
+    auto evt = SpiEvent{nullptr, &value, 1};
+    for (auto callback : callbacks) callback(evt);
+    return value;
+  }
+
+  uint8_t transfer(uint8_t write_value) {
+    uint8_t read_value = 0xFF;
+    auto evt = SpiEvent{&write_value, &read_value, 1};
+    for (auto callback : callbacks) callback(evt);
+    return read_value;
+  }
+
+  template<typename DataType>
+  void transfer(DataType* write_from, DataType* read_into, size_t length, bool source_increment = true) {
+    uint8_t* data = nullptr;
+
+    // uint16_t Endian swap hack
+    if (sizeof(DataType) == 2) {
+      if (source_increment) {
+        data = new uint8_t[sizeof(DataType) * length];
+        for (size_t i = 0; i < length; i ++) {
+          data[(i * 2)] = (write_from[i] >> 8) & 0xFF;
+          data[(i * 2) + 1] = (write_from[i] & 0xFF);
+        }
+      } else {
+        data = new uint8_t[sizeof(DataType)];
+        data[0] = (write_from[0] >> 8) & 0xFF;
+        data[1] = (write_from[0] & 0xFF);
+      }
+    } else {
+      data = (uint8_t*)write_from;
+    }
+
+    auto evt = SpiEvent{data, (uint8_t*)read_into, sizeof(DataType) * length, source_increment, sizeof(DataType)};
+    for (auto callback : callbacks) callback(evt);
+
+    if ((void*)data != (void*)write_from) delete data;
+  }
+
+  template<class... Args>
+  void attach(Args... args) {
+    callbacks.push_back(std::function<void(SpiEvent&)>(args...));
+  }
+
+  void acquire() { if(busy == true) printf("spi bus contention!\n"); busy = true; }
+  void release() { busy = false; }
+  bool is_busy() { return busy; }
+
+private:
+  std::vector<std::function<void(SpiEvent&)>> callbacks;
+  bool busy = false;
+};
+
+extern SpiBus SpiBus0;
+extern SpiBus SpiBus1;
+extern SpiBus SpiBus2;
+extern SpiBus SpiBus3;
+
+template <pin_type CLK, pin_type MOSI, pin_type MISO>
+SpiBus& spi_bus_by_pins();
+

--- a/src/MarlinSimulator/hardware/print_bed.h
+++ b/src/MarlinSimulator/hardware/print_bed.h
@@ -10,7 +10,7 @@
 
 class PrintBed : public VirtualPrinter::Component {
 public:
-  PrintBed(glm::vec2 size) : VirtualPrinter::Component("PrintBed"), bed_size(size), bed_plane_center({size.x/2, size.y/2, 0}), bed_level_points{glm::vec3{bed_size.x / 2, bed_size.y, 0}, {0, 0, 0}, {bed_size.x, 0, 0}} {}
+  PrintBed(glm::vec2 size, glm::vec2 offset) : VirtualPrinter::Component("PrintBed"), bed_size(size), bed_plane_center({size.x/2, size.y/2, 0}), bed_offset(offset), bed_level_points{glm::vec3{bed_size.x / 2, bed_size.y, 0}, {0, 0, 0}, {bed_size.x, 0, 0}} {}
 
   void ui_widget() {
     int8_t updated = 0;
@@ -40,5 +40,6 @@ public:
   glm::vec2 bed_size{200, 200};
   glm::vec3 bed_plane_center{100, 100, 0};
   glm::vec3 bed_plane_normal{0, 0, 1};
+  glm::vec2 bed_offset{0, 0};
   std::array<glm::vec3, 3> bed_level_points;
 };

--- a/src/MarlinSimulator/marlin_hal_impl/HAL.cpp
+++ b/src/MarlinSimulator/marlin_hal_impl/HAL.cpp
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#ifdef __PLAT_NATIVE_SIM__
 
 #include <src/inc/MarlinConfig.h>
 #include <src/HAL/shared/Delay.h>
@@ -88,5 +87,3 @@ void SYSTICK_IRQHandler() {
   systick_uptime_millis++;
   if (systick_user_callback) systick_user_callback();
 }
-
-#endif // __PLAT_NATIVE_SIM__

--- a/src/MarlinSimulator/marlin_hal_impl/eeprom.cpp
+++ b/src/MarlinSimulator/marlin_hal_impl/eeprom.cpp
@@ -19,8 +19,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#ifdef __PLAT_NATIVE_SIM__
-
 #include <src/inc/MarlinConfig.h>
 
 #if ENABLED(EEPROM_SETTINGS)
@@ -108,4 +106,3 @@ bool PersistentStore::read_data(int &pos, uint8_t *value, const size_t size, uin
 }
 
 #endif // EEPROM_SETTINGS
-#endif // __PLAT_NATIVE_SIM__

--- a/src/MarlinSimulator/marlin_hal_impl/timers.cpp
+++ b/src/MarlinSimulator/marlin_hal_impl/timers.cpp
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#ifdef __PLAT_NATIVE_SIM__
 
 #include <src/inc/MarlinConfig.h>
 
@@ -62,5 +61,3 @@ hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
 hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   return Kernel::Timers::timerGetCount(timer_num);
 }
-
-#endif // __PLAT_NATIVE_SIM__

--- a/src/MarlinSimulator/virtual_printer.cpp
+++ b/src/MarlinSimulator/virtual_printer.cpp
@@ -20,6 +20,10 @@
 
 #include <src/inc/MarlinConfig.h>
 
+#if HAS_TFT_XPT2046 || HAS_TOUCH_XPT2046
+  #include HAL_PATH(src/HAL, tft/xpt2046.h)
+#endif
+
 #ifndef SD_DETECT_STATE
   #define SD_DETECT_STATE HIGH
 #endif
@@ -57,7 +61,7 @@ void VirtualPrinter::build() {
     root->add_component<EndStop>("Endstop(Z Min)", Z_MIN_PIN, Z_MIN_ENDSTOP_INVERTING, [kinematics](){ return kinematics->effector_position.z <= 0; });
   #endif
 
-  auto print_bed = root->add_component<PrintBed>("Print Bed", glm::vec2{X_BED_SIZE, Y_BED_SIZE});
+  auto print_bed = root->add_component<PrintBed>("Print Bed", glm::vec2{X_BED_SIZE, Y_BED_SIZE}, glm::vec2{-X_MAX_POS, -Y_MAX_POS});
 
   #if HAS_BED_PROBE
     root->add_component<BedProbe>("Probe", Z_MIN_PROBE_PIN, glm::vec3 NOZZLE_TO_PROBE_OFFSET, kinematics->effector_position, *print_bed);
@@ -66,17 +70,20 @@ void VirtualPrinter::build() {
   root->add_component<Heater>("Hotend Heater", HEATER_0_PIN, TEMP_0_PIN, heater_data{12, 3.6}, hotend_data{13, 20, 0.897}, adc_data{4700, 12});
   root->add_component<Heater>("Bed Heater", HEATER_BED_PIN, TEMP_BED_PIN, heater_data{12, 1.2}, hotend_data{325, 824, 0.897}, adc_data{4700, 12});
   #if HAS_SPI_FLASH
-    root->add_component<W25QxxDevice>("SPI Flash", SPI_FLASH_SCK_PIN, SPI_FLASH_MISO_PIN, SPI_FLASH_MOSI_PIN, SPI_FLASH_CS_PIN, SPI_FLASH_SIZE);
+    //root->add_component<W25QxxDevice>("SPI Flash", SPI_FLASH_SCK_PIN, SPI_FLASH_MISO_PIN, SPI_FLASH_MOSI_PIN, SPI_FLASH_CS_PIN, SPI_FLASH_SIZE);
+    root->add_component<W25QxxDevice>("SPI Flash", spi_bus_by_pins<SPI_FLASH_SCK_PIN, SPI_FLASH_MOSI_PIN, SPI_FLASH_MISO_PIN>(), SPI_FLASH_CS_PIN, SPI_FLASH_SIZE);
   #endif
   #ifdef SDSUPPORT
-    root->add_component<SDCard>("SD Card", SD_SCK_PIN, SD_MISO_PIN, SD_MOSI_PIN, SDSS, SD_DETECT_PIN, SD_DETECT_STATE);
+    //root->add_component<SDCard>("SD Card", SD_SCK_PIN, SD_MISO_PIN, SD_MOSI_PIN, SDSS, SD_DETECT_PIN, SD_DETECT_STATE);
+    root->add_component<SDCard>("SD Card", spi_bus_by_pins<SD_SCK_PIN, SD_MOSI_PIN, SD_MISO_PIN>(), SD_SS_PIN, SD_DETECT_PIN, SD_DETECT_STATE);
   #endif
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
     root->add_component<FilamentRunoutSensor>("Filament Runout Sensor", FIL_RUNOUT1_PIN, FIL_RUNOUT_STATE);
   #endif
 
   #if ENABLED(TFT_INTERFACE_SPI)
-    root->add_component<ST7796Device>("ST7796Device Display", SD_SCK_PIN, TFT_MISO_PIN, TFT_MOSI_PIN, TFT_CS_PIN, TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, BTN_BACK, KILL_PIN);
+    //root->add_component<ST7796Device>("ST7796Device Display", TFT_SCK_PIN, TFT_MISO_PIN, TFT_MOSI_PIN, TFT_CS_PIN, TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, BTN_BACK, KILL_PIN);
+    root->add_component<ST7796Device>("ST7796Device Display", spi_bus_by_pins<TFT_SCK_PIN, TFT_MOSI_PIN, TFT_MISO_PIN>(), TFT_CS_PIN, spi_bus_by_pins<TOUCH_SCK_PIN, TOUCH_MOSI_PIN, TOUCH_MISO_PIN>(), TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, BTN_BACK, KILL_PIN);
   #elif defined(HAS_MARLINUI_HD44780)
     root->add_component<HD44780Device>("HD44780Device Display", LCD_PINS_RS, LCD_PINS_ENABLE, LCD_PINS_D4, LCD_PINS_D5, LCD_PINS_D6, LCD_PINS_D7, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, BTN_BACK, KILL_PIN);
   #elif defined(HAS_MARLINUI_U8GLIB)


### PR DESCRIPTION
Improve SPI performance for SD cards and TFT displays,
u8glib displays still use bitbang but can be moved over once the implementation files are moved from Marlin