### PR TITLE
Simulation: sleep rather than yield during realtime sync at low speed

### DIFF
--- a/src/MarlinSimulator/execution_control.h
+++ b/src/MarlinSimulator/execution_control.h
@@ -84,7 +84,7 @@ public:
       } else while (getTicks() > getRealtimeTicks()) {
         if (quit_requested) throw (std::runtime_error("Quit Requested"));  // quit program when stuck at 0 speed
         updateRealtime();
-        std::this_thread::yield();
+        realtime_scale > 20.0f ?  std::this_thread::yield() : std::this_thread::sleep_for(std::chrono::nanoseconds(1));
       }
     }
 

--- a/src/MarlinSimulator/main.cpp
+++ b/src/MarlinSimulator/main.cpp
@@ -54,7 +54,6 @@ void simulation_main() {
       printf("Marlin thread terminated\n");
       main_finished = true;
     }
-    std::this_thread::yield();
   }
 }
 


### PR DESCRIPTION
execution control: At lower simulation speed sleeping instead of yeilding will lower the cpu usage considerably
RawSocketSerial: sleep rather than yield