### PR TITLE
HAL_PATH(src/HAL, tft/tft_spi.h) compilation error

### DIFF
--- a/src/MarlinSimulator/marlin_hal_impl/tft/tft_spi.cpp
+++ b/src/MarlinSimulator/marlin_hal_impl/tft/tft_spi.cpp
@@ -24,7 +24,7 @@
 
 #if HAS_SPI_TFT
 
-#include HAL_PATH(src/HAL, tft/tft_spi.h)
+#include HAL_PATH(src, tft/tft_spi.h)
 #include "../../hardware/bus/spi.h"
 
 static SpiBus &spi_bus = spi_bus_by_pins<TFT_SCK_PIN, TFT_MOSI_PIN, TFT_MISO_PIN>();

--- a/src/MarlinSimulator/marlin_hal_impl/tft/xpt2046.cpp
+++ b/src/MarlinSimulator/marlin_hal_impl/tft/xpt2046.cpp
@@ -21,7 +21,7 @@
 
 #if HAS_TFT_XPT2046 || HAS_TOUCH_XPT2046
 
-#include HAL_PATH(src/HAL, tft/xpt2046.h)
+#include HAL_PATH(src, tft/xpt2046.h)
 #include "../../hardware/bus/spi.h"
 
 static SpiBus &spi_bus = spi_bus_by_pins<TOUCH_SCK_PIN, TOUCH_MOSI_PIN, TOUCH_MISO_PIN>();

--- a/src/MarlinSimulator/virtual_printer.cpp
+++ b/src/MarlinSimulator/virtual_printer.cpp
@@ -21,7 +21,7 @@
 #include <src/inc/MarlinConfig.h>
 
 #if HAS_TFT_XPT2046 || HAS_TOUCH_XPT2046
-  #include HAL_PATH(src/HAL, tft/xpt2046.h)
+  #include HAL_PATH(src, tft/xpt2046.h)
 #endif
 
 #ifndef SD_DETECT_STATE


### PR DESCRIPTION
`HAL_PATH(src/HAL, tft/tft_spi.h)` results in` src/HAL/HAL/...` path with one `HAL` too many.

Simulator doesn't compile because of that. I have found that in multiple places in MarlinFirmware codebase.