### PR TITLE
Improve LCD screen fitting

### DIFF
--- a/src/MarlinSimulator/hardware/HD44780Device.cpp
+++ b/src/MarlinSimulator/hardware/HD44780Device.cpp
@@ -6,8 +6,7 @@
 
 #include <gl.h>
 
-#include <imgui.h>
-#include <imgui_internal.h>
+#include "../imgui_custom.h"
 
 #include "HD44780Device.h"
 #include "HD44780DeviceROM.h"
@@ -211,31 +210,12 @@ void HD44780Device::ui_widget() {
     ImGui::Checkbox("Popout", &render_popout);
 
     if (render_popout) {
-      constexpr uint32_t hfeat = 1 + 7 + 7 + 1, vfeat = 1 + 18 + 1 + 7 + 7 + 1;
-      typedef struct { uint32_t minw, minh; float ratio; } constraint_t;
-      const constraint_t constraint { width + hfeat, height + vfeat, (width) / (float)(height) };
-
+      const imgui_custom::constraint_t constraint { width + imgui_custom::hfeat, height + imgui_custom::vfeat, (width) / (float)(height) };
       // Init the window size to contain the 2x scaled screen, margin, and window features
       ImGui::SetNextWindowSize(ImVec2(constraint.minw + width, constraint.minh + height), ImGuiCond_Once);
+      ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX), imgui_custom::CustomConstraints::AspectRatio, (void*)&constraint);
 
-      struct CustomConstraints {
-        static void AspectRatio(ImGuiSizeCallbackData *data) {
-          constraint_t c = *(constraint_t*)data->UserData;
-          uint32_t x = std::max((uint32_t)data->DesiredSize.x, c.minw),
-                   y = std::max((uint32_t)data->DesiredSize.y, c.minh);
-          // For Portrait, Y takes precedence, else X takes precedence
-          if (c.ratio < 1.0f)
-            x = std::floor((y - vfeat) * c.ratio) + hfeat;
-          else
-            y = std::floor((x - hfeat) / c.ratio) + vfeat;
-          data->DesiredSize.x = x;
-          data->DesiredSize.y = y;
-        }
-      };
-
-      ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX), CustomConstraints::AspectRatio, (void*)&constraint);
-
-      popout_begin = ImGui::Begin("ST7796DeviceRender", &render_popout);
+      popout_begin = ImGui::Begin("HD44780DeviceRender", &render_popout);
       if (!popout_begin) {
         ImGui::End();
         return;
@@ -244,21 +224,7 @@ void HD44780Device::ui_widget() {
     }
 
     // Apply the smallest scale that fits the window. Maintain proportions.
-    double scalex = size.x / width, scaley = size.y / height;
-    if (scalex < scaley) {
-      if (render_integer_scaling) {
-        if (scalex > 1.0) scalex = std::floor(scalex);
-        size.x = width * scalex;
-      }
-      size.y = height * scalex;
-    }
-    else {
-      if (render_integer_scaling) {
-        if (scaley > 1.0) scaley = std::floor(scaley);
-        size.y = height * scaley;
-      }
-      size.x = width * scaley;
-    }
+    size = imgui_custom::scale_proportionally(size, width, height, render_integer_scaling);
 
     ImGui::Image((ImTextureID)(intptr_t)texture_id, size, ImVec2(0,0), ImVec2(1,1));
     if (ImGui::IsWindowFocused()) {

--- a/src/MarlinSimulator/hardware/HD44780Device.cpp
+++ b/src/MarlinSimulator/hardware/HD44780Device.cpp
@@ -209,8 +209,11 @@ void HD44780Device::ui_widget() {
     ImGui::GetCurrentWindow()->ScrollMax.y = 1.0f; // disable window scroll
     ImGui::Checkbox("Integer Scaling", &render_integer_scaling);
     ImGui::Checkbox("Popout", &render_popout);
+
     if (render_popout) {
-      ImGui::SetNextWindowSize(ImVec2(width + 10, height + 10), ImGuiCond_Once);
+      constexpr uint32_t hfeat = 1 + 7 + 7 + 1, vfeat = 1 + 18 + 1 + 7 + 7 + 1;
+      ImGui::SetNextWindowSize(ImVec2(width + hfeat, height + vfeat), ImGuiCond_Once);
+
       popout_begin = ImGui::Begin("ST7796DeviceRender", &render_popout);
       if (!popout_begin) {
         ImGui::End();

--- a/src/MarlinSimulator/hardware/HD44780Device.cpp
+++ b/src/MarlinSimulator/hardware/HD44780Device.cpp
@@ -212,7 +212,28 @@ void HD44780Device::ui_widget() {
 
     if (render_popout) {
       constexpr uint32_t hfeat = 1 + 7 + 7 + 1, vfeat = 1 + 18 + 1 + 7 + 7 + 1;
-      ImGui::SetNextWindowSize(ImVec2(width + hfeat, height + vfeat), ImGuiCond_Once);
+      typedef struct { uint32_t minw, minh; float ratio; } constraint_t;
+      const constraint_t constraint { width + hfeat, height + vfeat, (width) / (float)(height) };
+
+      // Init the window size to contain the 2x scaled screen, margin, and window features
+      ImGui::SetNextWindowSize(ImVec2(constraint.minw + width, constraint.minh + height), ImGuiCond_Once);
+
+      struct CustomConstraints {
+        static void AspectRatio(ImGuiSizeCallbackData *data) {
+          constraint_t c = *(constraint_t*)data->UserData;
+          uint32_t x = std::max((uint32_t)data->DesiredSize.x, c.minw),
+                   y = std::max((uint32_t)data->DesiredSize.y, c.minh);
+          // For Portrait, Y takes precedence, else X takes precedence
+          if (c.ratio < 1.0f)
+            x = std::floor((y - vfeat) * c.ratio) + hfeat;
+          else
+            y = std::floor((x - hfeat) / c.ratio) + vfeat;
+          data->DesiredSize.x = x;
+          data->DesiredSize.y = y;
+        }
+      };
+
+      ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX), CustomConstraints::AspectRatio, (void*)&constraint);
 
       popout_begin = ImGui::Begin("ST7796DeviceRender", &render_popout);
       if (!popout_begin) {

--- a/src/MarlinSimulator/hardware/HD44780Device.cpp
+++ b/src/MarlinSimulator/hardware/HD44780Device.cpp
@@ -222,12 +222,22 @@ void HD44780Device::ui_widget() {
       size = ImGui::GetContentRegionAvail();
     }
 
-    double scale = size.x / width;
-    if (render_integer_scaling) {
-      scale = scale > 1.0 ? std::floor(scale) : scale;
-      size.x = width * scale;
+    // Apply the smallest scale that fits the window. Maintain proportions.
+    double scalex = size.x / width, scaley = size.y / height;
+    if (scalex < scaley) {
+      if (render_integer_scaling) {
+        if (scalex > 1.0) scalex = std::floor(scalex);
+        size.x = width * scalex;
+      }
+      size.y = height * scalex;
     }
-    size.y = height * scale;
+    else {
+      if (render_integer_scaling) {
+        if (scaley > 1.0) scaley = std::floor(scaley);
+        size.y = height * scaley;
+      }
+      size.x = width * scaley;
+    }
 
     ImGui::Image((ImTextureID)(intptr_t)texture_id, size, ImVec2(0,0), ImVec2(1,1));
     if (ImGui::IsWindowFocused()) {

--- a/src/MarlinSimulator/hardware/HD44780Device.cpp
+++ b/src/MarlinSimulator/hardware/HD44780Device.cpp
@@ -129,7 +129,7 @@ void HD44780Device::update() {
 
           for (std::size_t ty = 0; ty < 8; ty++ ) {
             for (std::size_t tx = 0; tx < 5; tx++ ) {
-              texture_data[((texture_index_y + ty) * texture_x) + texture_index_x - tx + 5] = TEST(charset[charset_base + ty], tx) ? forground_color : background_color;
+              texture_data[((texture_index_y + ty) * texture_x) + texture_index_x - tx + 5] = TEST(charset[charset_base + ty], tx) ? foreground_color : background_color;
             }
           }
         }

--- a/src/MarlinSimulator/hardware/HD44780Device.h
+++ b/src/MarlinSimulator/hardware/HD44780Device.h
@@ -99,7 +99,7 @@ public:
 
   glm::vec<3, uint8_t> texture_data[texture_x * texture_y] = {};
 
-  glm::ivec3 forground_color = {0x81, 0xF2, 0xFF};
+  glm::ivec3 foreground_color = {0x81, 0xF2, 0xFF};
   glm::ivec3 background_color = {0x33, 0x01, 0xFC};
   glm::ivec3 display_color = {0x23, 0x2A, 0xFC};
 

--- a/src/MarlinSimulator/hardware/ST7796Device.cpp
+++ b/src/MarlinSimulator/hardware/ST7796Device.cpp
@@ -147,12 +147,22 @@ void ST7796Device::ui_widget() {
       size = ImGui::GetContentRegionAvail();
     }
 
-    double scale = size.x / width;
-    if (render_integer_scaling) {
-      scale = scale > 1.0 ? std::floor(scale) : scale;
-      size.x = width * scale;
+    // Apply the smallest scale that fits the window. Maintain proportions.
+    double scalex = size.x / width, scaley = size.y / height;
+    if (scalex < scaley) {
+      if (render_integer_scaling) {
+        if (scalex > 1.0) scalex = std::floor(scalex);
+        size.x = width * scalex;
+      }
+      size.y = height * scalex;
     }
-    size.y = height * scale;
+    else {
+      if (render_integer_scaling) {
+        if (scaley > 1.0) scaley = std::floor(scaley);
+        size.y = height * scaley;
+      }
+      size.x = width * scaley;
+    }
 
     ImGui::Image((ImTextureID)(intptr_t)texture_id, size, ImVec2(0,0), ImVec2(1,1));
     touch->ui_callback();

--- a/src/MarlinSimulator/hardware/ST7796Device.cpp
+++ b/src/MarlinSimulator/hardware/ST7796Device.cpp
@@ -136,7 +136,9 @@ void ST7796Device::ui_widget() {
     ImGui::Checkbox("Popout", &render_popout);
 
     if (render_popout) {
-      ImGui::SetNextWindowSize(ImVec2(width + 10, height + 10), ImGuiCond_Once);
+      constexpr uint32_t hfeat = 1 + 7 + 7 + 1, vfeat = 1 + 18 + 1 + 7 + 7 + 1;
+      ImGui::SetNextWindowSize(ImVec2(width + hfeat, height + vfeat), ImGuiCond_Once);
+
       popout_begin = ImGui::Begin("ST7796DeviceRender", &render_popout);
       if (!popout_begin) {
         ImGui::End();

--- a/src/MarlinSimulator/hardware/ST7796Device.cpp
+++ b/src/MarlinSimulator/hardware/ST7796Device.cpp
@@ -137,7 +137,28 @@ void ST7796Device::ui_widget() {
 
     if (render_popout) {
       constexpr uint32_t hfeat = 1 + 7 + 7 + 1, vfeat = 1 + 18 + 1 + 7 + 7 + 1;
-      ImGui::SetNextWindowSize(ImVec2(width + hfeat, height + vfeat), ImGuiCond_Once);
+      typedef struct { uint32_t minw, minh; float ratio; } constraint_t;
+      const constraint_t constraint { width + hfeat, height + vfeat, (width) / (float)(height) };
+
+      // Init the window size to contain the 1x scaled screen, margin, and window features
+      ImGui::SetNextWindowSize(ImVec2(constraint.minw, constraint.minh), ImGuiCond_Once);
+
+      struct CustomConstraints {
+        static void AspectRatio(ImGuiSizeCallbackData *data) {
+          constraint_t c = *(constraint_t*)data->UserData;
+          uint32_t x = std::max((uint32_t)data->DesiredSize.x, c.minw),
+                   y = std::max((uint32_t)data->DesiredSize.y, c.minh);
+          // For Portrait, Y takes precedence, else X takes precedence
+          if (c.ratio < 1.0f)
+            x = std::floor((y - vfeat) * c.ratio) + hfeat;
+          else
+            y = std::floor((x - hfeat) / c.ratio) + vfeat;
+          data->DesiredSize.x = x;
+          data->DesiredSize.y = y;
+        }
+      };
+
+      ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX), CustomConstraints::AspectRatio, (void*)&constraint);
 
       popout_begin = ImGui::Begin("ST7796DeviceRender", &render_popout);
       if (!popout_begin) {

--- a/src/MarlinSimulator/hardware/ST7920Device.cpp
+++ b/src/MarlinSimulator/hardware/ST7920Device.cpp
@@ -165,7 +165,9 @@ void ST7920Device::ui_widget() {
     ImGui::Checkbox("Popout", &render_popout);
 
     if (render_popout) {
-      ImGui::SetNextWindowSize(ImVec2(width + 10, height + 10), ImGuiCond_Once);
+      constexpr uint32_t hfeat = 1 + 7 + 7 + 1, vfeat = 1 + 18 + 1 + 7 + 7 + 1;
+      ImGui::SetNextWindowSize(ImVec2(width + hfeat, height + vfeat), ImGuiCond_Once);
+
       popout_begin = ImGui::Begin("ST7920DeviceRender", &render_popout);
       if (!popout_begin) {
         ImGui::End();

--- a/src/MarlinSimulator/hardware/ST7920Device.cpp
+++ b/src/MarlinSimulator/hardware/ST7920Device.cpp
@@ -95,7 +95,7 @@ void ST7920Device::update() {
         std::size_t texture_index = (y * 128) + x;             // indexed by pixel coordinate
         std::size_t graphic_ram_index = (y * 32) + (x / 8);    // indexed by byte (8 horizontal pixels), 32 byte (256 pixel) stride per row
         for (std::size_t j = 0; j < 8; j++) {
-          texture_data[texture_index + j] = TEST(graphic_ram[graphic_ram_index], 7 - j) ? forground_color :  background_color;
+          texture_data[texture_index + j] = TEST(graphic_ram[graphic_ram_index], 7 - j) ? foreground_color :  background_color;
         }
       }
     }

--- a/src/MarlinSimulator/hardware/ST7920Device.cpp
+++ b/src/MarlinSimulator/hardware/ST7920Device.cpp
@@ -6,8 +6,7 @@
 
 #include <gl.h>
 
-#include "imgui.h"
-#include "imgui_internal.h"
+#include "../imgui_custom.h"
 
 #include "ST7920Device.h"
 
@@ -165,29 +164,11 @@ void ST7920Device::ui_widget() {
     ImGui::Checkbox("Popout", &render_popout);
 
     if (render_popout) {
-      constexpr uint32_t hfeat = 1 + 7 + 7 + 1, vfeat = 1 + 18 + 1 + 7 + 7 + 1;
-      typedef struct { uint32_t minw, minh; float ratio; } constraint_t;
-      const constraint_t constraint { width + hfeat, height + vfeat, (width) / (float)(height) };
+      const imgui_custom::constraint_t constraint { width + imgui_custom::hfeat, height + imgui_custom::vfeat, (width) / (float)(height) };
 
       // Init the window size to contain the 2x scaled screen, margin, and window features
       ImGui::SetNextWindowSize(ImVec2(constraint.minw + width, constraint.minh + height), ImGuiCond_Once);
-
-      struct CustomConstraints {
-        static void AspectRatio(ImGuiSizeCallbackData *data) {
-          constraint_t c = *(constraint_t*)data->UserData;
-          uint32_t x = std::max((uint32_t)data->DesiredSize.x, c.minw),
-                   y = std::max((uint32_t)data->DesiredSize.y, c.minh);
-          // For Portrait, Y takes precedence, else X takes precedence
-          if (c.ratio < 1.0f)
-            x = std::floor((y - vfeat) * c.ratio) + hfeat;
-          else
-            y = std::floor((x - hfeat) / c.ratio) + vfeat;
-          data->DesiredSize.x = x;
-          data->DesiredSize.y = y;
-        }
-      };
-
-      ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX), CustomConstraints::AspectRatio, (void*)&constraint);
+      ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX), imgui_custom::CustomConstraints::AspectRatio, (void*)&constraint);
 
       popout_begin = ImGui::Begin("ST7920DeviceRender", &render_popout);
       if (!popout_begin) {
@@ -198,21 +179,7 @@ void ST7920Device::ui_widget() {
     }
 
     // Apply the smallest scale that fits the window. Maintain proportions.
-    double scalex = size.x / width, scaley = size.y / height;
-    if (scalex < scaley) {
-      if (render_integer_scaling) {
-        if (scalex > 1.0) scalex = std::floor(scalex);
-        size.x = width * scalex;
-      }
-      size.y = height * scalex;
-    }
-    else {
-      if (render_integer_scaling) {
-        if (scaley > 1.0) scaley = std::floor(scaley);
-        size.y = height * scaley;
-      }
-      size.x = width * scaley;
-    }
+    size = imgui_custom::scale_proportionally(size, width, height, render_integer_scaling);
 
     ImGui::Image((ImTextureID)(intptr_t)texture_id, size, ImVec2(0,0), ImVec2(1,1));
     if (ImGui::IsWindowFocused()) {

--- a/src/MarlinSimulator/hardware/ST7920Device.cpp
+++ b/src/MarlinSimulator/hardware/ST7920Device.cpp
@@ -176,12 +176,22 @@ void ST7920Device::ui_widget() {
       size = ImGui::GetContentRegionAvail();
     }
 
-    double scale = size.x / width;
-    if (render_integer_scaling) {
-      scale = scale > 1.0 ? std::floor(scale) : scale;
-      size.x = width * scale;
+    // Apply the smallest scale that fits the window. Maintain proportions.
+    double scalex = size.x / width, scaley = size.y / height;
+    if (scalex < scaley) {
+      if (render_integer_scaling) {
+        if (scalex > 1.0) scalex = std::floor(scalex);
+        size.x = width * scalex;
+      }
+      size.y = height * scalex;
     }
-    size.y = height * scale;
+    else {
+      if (render_integer_scaling) {
+        if (scaley > 1.0) scaley = std::floor(scaley);
+        size.y = height * scaley;
+      }
+      size.x = width * scaley;
+    }
 
     ImGui::Image((ImTextureID)(intptr_t)texture_id, size, ImVec2(0,0), ImVec2(1,1));
     if (ImGui::IsWindowFocused()) {

--- a/src/MarlinSimulator/hardware/ST7920Device.h
+++ b/src/MarlinSimulator/hardware/ST7920Device.h
@@ -71,6 +71,6 @@ public:
   GLuint texture_id;
   glm::vec<3, uint8_t> texture_data[128*64] = {};
 
-  glm::ivec3 forground_color = {0x81, 0xF2, 0xFF};
+  glm::ivec3 foreground_color = {0x81, 0xF2, 0xFF};
   glm::ivec3 background_color = {0x33, 0x01, 0xFC};
 };

--- a/src/MarlinSimulator/imgui_custom.h
+++ b/src/MarlinSimulator/imgui_custom.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <imgui.h>
+#include <imgui_internal.h>
+
+namespace imgui_custom {
+  constexpr uint32_t hfeat = 1 + 7 + 7 + 1, vfeat = 1 + 18 + 1 + 7 + 7 + 1;
+  typedef struct { uint32_t minw, minh; float ratio; } constraint_t;
+  struct CustomConstraints {
+    static void AspectRatio(ImGuiSizeCallbackData *data) {
+      constraint_t c = *(constraint_t*)data->UserData;
+      uint32_t x = std::max((uint32_t)data->DesiredSize.x, c.minw),
+               y = std::max((uint32_t)data->DesiredSize.y, c.minh);
+      // For Portrait, Y takes precedence, else X takes precedence
+      if (c.ratio < 1.0f)
+        x = std::floor((y - vfeat) * c.ratio) + hfeat;
+      else
+        y = std::floor((x - hfeat) / c.ratio) + vfeat;
+      data->DesiredSize.x = x;
+      data->DesiredSize.y = y;
+    }
+  };
+
+  ImVec2 scale_proportionally(ImVec2 size, double width, double height, bool integer_scaling) {
+    double scalex = size.x / width, scaley = size.y / height;
+    if (scalex < scaley) {
+      if (integer_scaling) {
+        if (scalex > 1.0) scalex = std::floor(scalex);
+        size.x = width * scalex;
+      }
+      size.y = height * scalex;
+    } else {
+      if (integer_scaling) {
+        if (scaley > 1.0) scaley = std::floor(scaley);
+        size.y = height * scaley;
+      }
+      size.x = width * scaley;
+    }
+    return size;
+  }
+}

--- a/src/MarlinSimulator/user_interface.h
+++ b/src/MarlinSimulator/user_interface.h
@@ -268,7 +268,7 @@ struct SerialMonitor : public UiWindow {
   }
 
   void show() {
-      // File read into serial port
+    // File read into serial port
     if (input_file.is_open() && serial_stream.receive_buffer.free() && streaming) {
       uint8_t buffer[HalSerial::receive_buffer_size]{};
       size_t read_size = std::min(serial_stream.receive_buffer.free(), stream_total - stream_sent);


### PR DESCRIPTION
- **Problem:** The way the LCD screen fitting interacts with the scroll bar can lead to an unwanted effect as the image rapidly oscillates between two sizes.
  - **Solution:** Add a larger margin around the image.

- **Problem:** The popout can be freely resized and the fitting always prefers the width, with vertical content potentially hidden and scrollable. This isn't especially useful.
  - **Solution 1:** Keep the entire image within the bounds of the popout window.
  - **Solution 2:** Constrain popout resizing to the aspect ratio of the screen.

If **Solution 2** is applied without **Solution 1** then scaling below 1x currently can lead to the same oscillation problem.

---
**Update:** Popout window features add up to 16px horizontal and 35px vertical. These are now defined and the constraints are now properly applied to account for the window features around the content area.