### PR TITLE
use LCD_WIDTH when available

### DIFF
--- a/src/MarlinSimulator/hardware/HD44780Device.cpp
+++ b/src/MarlinSimulator/hardware/HD44780Device.cpp
@@ -111,7 +111,7 @@ void HD44780Device::update() {
     dirty = false;
 
     if (state.display_lines == 2) {
-      uint32_t line_length = 80 / state.display_lines;
+      uint32_t line_length = (LCD_WIDTH*4) / state.display_lines;
       for (std::size_t line = 0; line < state.display_lines; line ++) {
         for (std::size_t line_xindex = 0; line_xindex < line_length; line_xindex ++) {
           uint32_t index = line * 0x40 + ((line_xindex + state.display_shift) % line_length);
@@ -121,8 +121,8 @@ void HD44780Device::update() {
           } else charset_base = ddram_buffer[index] * 0x10;
           uint8_t* charset = (ddram_buffer[index] < 0x10) ? cgram_buffer : active_rom;
 
-          uint16_t x = line_xindex > 19 ? line_xindex - 20 : line_xindex;
-          uint16_t y = (line == 1) | ((line_xindex > 19) << 1);
+          uint16_t x = line_xindex > LCD_WIDTH-1 ? line_xindex - LCD_WIDTH : line_xindex;
+          uint16_t y = (line == 1) | ((line_xindex > LCD_WIDTH-1) << 1);
 
           uint16_t texture_index_x = display_margin + (5 + display_char_pad) * x;
           uint16_t texture_index_y = display_margin + (8 + display_char_pad) * y;

--- a/src/MarlinSimulator/hardware/HD44780Device.h
+++ b/src/MarlinSimulator/hardware/HD44780Device.h
@@ -11,6 +11,10 @@
 #include "../virtual_printer.h"
 #include "Gpio.h"
 
+#ifndef LCD_WIDTH
+  #define LCD_WIDTH 20
+#endif
+
 class HD44780Device: public VirtualPrinter::Component {
 public:
   enum KeyName {
@@ -86,12 +90,12 @@ public:
   float scaler;
   GLuint texture_id;
 
-  static constexpr uint32_t display_x_char = 20;
+  static constexpr uint32_t display_x_char = LCD_WIDTH;
   static constexpr uint32_t display_y_char = 4;
   static constexpr uint32_t display_margin = 6;
   static constexpr uint32_t display_char_pad = 1;
 
-  static constexpr uint32_t texture_x = 132;//((5 * display_x_char) + (display_margin * 2) + (19 * display_char_pad));
+  static constexpr uint32_t texture_x = 1+(5 * display_x_char)+(display_margin * 2)+(19 * display_char_pad);//((5 * display_x_char) + (display_margin * 2) + (19 * display_char_pad));
   static constexpr uint32_t texture_y = 48;//((8 * display_y_char) + (display_margin * 2) + (3 * display_char_pad));
   static constexpr uint32_t width = texture_x, height = texture_y;
   bool render_integer_scaling = false, render_popout = false;


### PR DESCRIPTION
Added support for LCD_WIDTH in HD44780

I was looking into a Marlin issue that needed a 16x4 lcd, the sim didn't seem to support this so I added it.

Now if you add the following to Configuration.h 
#define REPRAP_DISCOUNT_SMART_CONTROLLER
#define LCD_WIDTH 16

you get a 16x4 lcd

![Image](https://github.com/user-attachments/assets/bbe66338-e433-456e-86b3-c720c31ead15)

 