### PR TITLE
only check LCD_WIDTH and LCD_HEIGHT on REPRAP_DISCOUNT_SMART_CONTROLLER's

### DIFF
--- a/src/MarlinSimulator/hardware/HD44780Device.h
+++ b/src/MarlinSimulator/hardware/HD44780Device.h
@@ -19,8 +19,10 @@
   #define LCD_HEIGHT 4
 #endif
 
-static_assert(LCD_WIDTH == 16 || LCD_WIDTH == 20, "Unsupported Character LCD Width");
-static_assert(LCD_HEIGHT == 2 || LCD_HEIGHT == 4, "Unsupported Character LCD Height");
+#ifdef REPRAP_DISCOUNT_SMART_CONTROLLER
+  static_assert(LCD_WIDTH == 16 || LCD_WIDTH == 20, "Unsupported Character LCD Width");
+  static_assert(LCD_HEIGHT == 2 || LCD_HEIGHT == 4, "Unsupported Character LCD Height");
+#endif
 
 class HD44780Device: public VirtualPrinter::Component {
 public:


### PR DESCRIPTION
TFT_COLOR_UI also uses LCD_HEIGHT and sets it to 6

This triggers the error "static assertion failed: Unsupported Character LCD Height"

The  two  static asserts 
```
static_assert(LCD_WIDTH == 16 || LCD_WIDTH == 20, "Unsupported Character LCD Width");
static_assert(LCD_HEIGHT == 2 || LCD_HEIGHT == 4, "Unsupported Character LCD Height");

```
Where only meant to be checked on character based  displays, so I wrapped this in a #ifdef REPRAP_DISCOUNT_SMART_CONTROLLER  block



 

