### PR TITLE
Warn for CYRILLIC, unknown

### DIFF
--- a/src/MarlinSimulator/hardware/HD44780Device.cpp
+++ b/src/MarlinSimulator/hardware/HD44780Device.cpp
@@ -38,8 +38,12 @@ HD44780Device::HD44780Device(pin_type rs, pin_type en, pin_type d4, pin_type d5,
     active_rom = hd44780_a00_rom;
   #elif DISPLAY_CHARSET_HD44780 == WESTERN
     active_rom = hd44780_a02_rom;
+  #elif DISPLAY_CHARSET_HD44780 == CYRILLIC
+    active_rom = hd44780_a02_rom;
+    #warning "CYRILLIC HD44780 Character ROM not available. Falling back to WESTERN."
   #else
-    #error Unavailable HD44780 Character ROM
+    active_rom = hd44780_a02_rom;
+    #warning "Unknown HD44780 Character ROM. Falling back to WESTERN."
   #endif
 }
 

--- a/src/MarlinSimulator/marlin_arduino_impl/arduino.cpp
+++ b/src/MarlinSimulator/marlin_arduino_impl/arduino.cpp
@@ -81,12 +81,17 @@ uint16_t analogRead(pin_t adc_pin) {
   return Gpio::get(digitalPinToAnalogIndex(adc_pin));
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 char *dtostrf(double __val, signed char __width, unsigned char __prec, char *__s) {
   char format_string[20];
   snprintf(format_string, 20, "%%%d.%df", __width, __prec);
   sprintf(__s, format_string, __val);
   return __s;
 }
+
+#pragma GCC diagnostic pop
 
 int32_t random(int32_t max) {
   return rand() % max;

--- a/src/MarlinSimulator/visualisation.h
+++ b/src/MarlinSimulator/visualisation.h
@@ -160,7 +160,6 @@ public:
   std::shared_ptr<renderer::ShaderProgram> default_program;
 
   bool mouse_captured = false;
-  bool input_state[6] = {};
   glm::vec<2, int> mouse_lock_pos;
 
   #define BED_NORMAL 0.0, 1.0, 0.0


### PR DESCRIPTION
Allow builds not using HD44780 that happen to have weird `DISPLAY_CHARSET_HD44780` values to pass.

Also suppress deprecated `sprintf` warnings to use `snprintf` that should instead be warning us to use Rust.