### PR TITLE
Add CORE support and endstop UI tweakss 

### DIFF
--- a/src/MarlinSimulator/hardware/EndStop.h
+++ b/src/MarlinSimulator/hardware/EndStop.h
@@ -15,22 +15,46 @@ public:
   ~EndStop() {}
 
   void ui_widget() {
-    bool value = (invert_logic ? !triggered() : triggered()) && enabled;
-    ImGui::Checkbox("Triggered", &value);
-    value = enabled;
-    ImGui::Checkbox("Enabled", &value);
-    enabled = value;
+    // Display the logical trigger state (not the electrical pin level)
+    bool logical_triggered = triggered();
+    bool display_value = manual_override.load() ? manual_trigger_state.load() : (logical_triggered && enabled.load());
+
+    if (ImGui::Checkbox("Triggered", &display_value)) {
+      manual_override = true;
+      manual_trigger_state = display_value;
+    }
+    ImGui::SameLine();
+
+    bool is_auto = !manual_override.load();
+    if (ImGui::Checkbox("Auto", &is_auto)) {
+      manual_override = !is_auto;
+    }
+
+    bool enabled_value = enabled.load();
+    if (ImGui::Checkbox("Enabled", &enabled_value)) {
+      enabled = enabled_value;
+    }
   }
 
   void interrupt(GpioEvent& ev) {
     if (ev.pin_id == endstop && ev.event == ev.GET_VALUE) {
-      Gpio::set_pin_value(ev.pin_id, (invert_logic ? !triggered() : triggered()) && enabled);
+      bool logical_state;
+      if (manual_override.load()) {
+        logical_state = manual_trigger_state.load();
+      } else {
+        logical_state = triggered() && enabled.load();
+      }
+      // Convert logical trigger state to electrical pin level based on HIT_STATE
+      bool pin_level = invert_logic ? !logical_state : logical_state;
+      Gpio::set_pin_value(ev.pin_id, pin_level);
     }
   }
 
 private:
   const pin_type endstop;
   std::atomic_bool enabled = true;
+  std::atomic_bool manual_override = false;
+  std::atomic_bool manual_trigger_state = false;
   bool invert_logic;
   std::function<bool()> triggered;
 };

--- a/src/MarlinSimulator/hardware/KinematicSystem.h
+++ b/src/MarlinSimulator/hardware/KinematicSystem.h
@@ -42,6 +42,54 @@ public:
   std::vector<double> extruder {};
 };
 
+class CoreXYKinematicSystem : public KinematicSystem {
+public:
+  CoreXYKinematicSystem(std::function<void(kinematic_state&)> on_kinematic_update);
+  virtual void ui_widget() override;
+  virtual void kinematic_update() override;
+  std::vector<double> extruder {};
+};
+
+class CoreXZKinematicSystem : public KinematicSystem {
+public:
+  CoreXZKinematicSystem(std::function<void(kinematic_state&)> on_kinematic_update);
+  virtual void ui_widget() override;
+  virtual void kinematic_update() override;
+  std::vector<double> extruder {};
+};
+
+class CoreYZKinematicSystem : public KinematicSystem {
+public:
+  CoreYZKinematicSystem(std::function<void(kinematic_state&)> on_kinematic_update);
+  virtual void ui_widget() override;
+  virtual void kinematic_update() override;
+  std::vector<double> extruder {};
+};
+
+class CoreYXKinematicSystem : public KinematicSystem {
+public:
+  CoreYXKinematicSystem(std::function<void(kinematic_state&)> on_kinematic_update);
+  virtual void ui_widget() override;
+  virtual void kinematic_update() override;
+  std::vector<double> extruder {};
+};
+
+class CoreZXKinematicSystem : public KinematicSystem {
+public:
+  CoreZXKinematicSystem(std::function<void(kinematic_state&)> on_kinematic_update);
+  virtual void ui_widget() override;
+  virtual void kinematic_update() override;
+  std::vector<double> extruder {};
+};
+
+class CoreZYKinematicSystem : public KinematicSystem {
+public:
+  CoreZYKinematicSystem(std::function<void(kinematic_state&)> on_kinematic_update);
+  virtual void ui_widget() override;
+  virtual void kinematic_update() override;
+  std::vector<double> extruder {};
+};
+
 class DeltaKinematicSystem : public KinematicSystem {
 public:
   DeltaKinematicSystem(std::function<void(kinematic_state&)> on_kinematic_update);

--- a/src/MarlinSimulator/virtual_printer.cpp
+++ b/src/MarlinSimulator/virtual_printer.cpp
@@ -60,14 +60,132 @@ void VirtualPrinter::build() {
     root->add_component<EndStop>("Endstop(Tower A Max)", X_MAX_PIN, !X_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].stepper_position.x >= DELTA_HEIGHT; });
     root->add_component<EndStop>("Endstop(Tower B Max)", Y_MAX_PIN, !Y_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].stepper_position.y >= DELTA_HEIGHT; });
     root->add_component<EndStop>("Endstop(Tower C Max)", Z_MAX_PIN, !Z_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].stepper_position.z >= DELTA_HEIGHT; });
+  #elif ENABLED(COREXY)
+    auto kinematics = root->add_component<CoreXYKinematicSystem>("CoreXY Kinematic System", on_kinematic_update);
+    #if X_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(X Min)", X_MIN_PIN, !X_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x <= X_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(X Max)", X_MAX_PIN, !X_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x >= X_MAX_POS; });
+    #endif
+    #if Y_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Y Min)", Y_MIN_PIN, !Y_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y <= Y_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Y Max)", Y_MAX_PIN, !Y_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y >= Y_MAX_POS; });
+    #endif
+    #if Z_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Z Min)", Z_MIN_PIN, !Z_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z <= Z_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Z Max)", Z_MAX_PIN, !Z_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z >= Z_MAX_POS; });
+    #endif
+  #elif ENABLED(COREXZ)
+    auto kinematics = root->add_component<CoreXZKinematicSystem>("CoreXZ Kinematic System", on_kinematic_update);
+    #if X_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(X Min)", X_MIN_PIN, !X_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x <= X_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(X Max)", X_MAX_PIN, !X_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x >= X_MAX_POS; });
+    #endif
+    #if Y_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Y Min)", Y_MIN_PIN, !Y_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y <= Y_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Y Max)", Y_MAX_PIN, !Y_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y >= Y_MAX_POS; });
+    #endif
+    #if Z_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Z Min)", Z_MIN_PIN, !Z_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z <= Z_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Z Max)", Z_MAX_PIN, !Z_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z >= Z_MAX_POS; });
+    #endif
+  #elif ENABLED(COREYZ)
+    auto kinematics = root->add_component<CoreYZKinematicSystem>("CoreYZ Kinematic System", on_kinematic_update);
+    #if X_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(X Min)", X_MIN_PIN, !X_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x <= X_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(X Max)", X_MAX_PIN, !X_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x >= X_MAX_POS; });
+    #endif
+    #if Y_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Y Min)", Y_MIN_PIN, !Y_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y <= Y_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Y Max)", Y_MAX_PIN, !Y_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y >= Y_MAX_POS; });
+    #endif
+    #if Z_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Z Min)", Z_MIN_PIN, !Z_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z <= Z_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Z Max)", Z_MAX_PIN, !Z_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z >= Z_MAX_POS; });
+    #endif
+  #elif ENABLED(COREYX)
+    auto kinematics = root->add_component<CoreYXKinematicSystem>("CoreYX Kinematic System", on_kinematic_update);
+    #if X_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(X Min)", X_MIN_PIN, !X_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x <= X_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(X Max)", X_MAX_PIN, !X_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x >= X_MAX_POS; });
+    #endif
+    #if Y_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Y Min)", Y_MIN_PIN, !Y_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y <= Y_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Y Max)", Y_MAX_PIN, !Y_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y >= Y_MAX_POS; });
+    #endif
+    #if Z_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Z Min)", Z_MIN_PIN, !Z_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z <= Z_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Z Max)", Z_MAX_PIN, !Z_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z >= Z_MAX_POS; });
+    #endif
+  #elif ENABLED(COREZX)
+    auto kinematics = root->add_component<CoreZXKinematicSystem>("CoreZX Kinematic System", on_kinematic_update);
+    #if X_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(X Min)", X_MIN_PIN, !X_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x <= X_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(X Max)", X_MAX_PIN, !X_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x >= X_MAX_POS; });
+    #endif
+    #if Y_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Y Min)", Y_MIN_PIN, !Y_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y <= Y_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Y Max)", Y_MAX_PIN, !Y_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y >= Y_MAX_POS; });
+    #endif
+    #if Z_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Z Min)", Z_MIN_PIN, !Z_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z <= Z_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Z Max)", Z_MAX_PIN, !Z_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z >= Z_MAX_POS; });
+    #endif
+  #elif ENABLED(COREZY)
+    auto kinematics = root->add_component<CoreZYKinematicSystem>("CoreZY Kinematic System", on_kinematic_update);
+    #if X_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(X Min)", X_MIN_PIN, !X_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x <= X_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(X Max)", X_MAX_PIN, !X_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x >= X_MAX_POS; });
+    #endif
+    #if Y_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Y Min)", Y_MIN_PIN, !Y_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y <= Y_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Y Max)", Y_MAX_PIN, !Y_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y >= Y_MAX_POS; });
+    #endif
+    #if Z_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Z Min)", Z_MIN_PIN, !Z_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z <= Z_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Z Max)", Z_MAX_PIN, !Z_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z >= Z_MAX_POS; });
+    #endif
   #else
     auto kinematics = root->add_component<CartesianKinematicSystem>("Cartesian Kinematic System", on_kinematic_update);
-    root->add_component<EndStop>("Endstop(X Min)", X_MIN_PIN, !X_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x <= X_MIN_POS; });
-    #ifdef DUAL_X_CARRIAGE
-      root->add_component<EndStop>("Endstop(X2 Max)", X_MAX_PIN, !X_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[1].position.x >= X2_MAX_POS; });
+    #if X_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(X Min)", X_MIN_PIN, !X_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x <= X_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(X Max)", X_MAX_PIN, !X_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.x >= X_MAX_POS; });
     #endif
-    root->add_component<EndStop>("Endstop(Y Min)", Y_MIN_PIN, !Y_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y <= Y_MIN_POS; });
-    root->add_component<EndStop>("Endstop(Z Min)", Z_MIN_PIN, !Z_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z <= Z_MIN_POS; });
+    #ifdef DUAL_X_CARRIAGE
+      #if X_HOME_DIR < 0
+        root->add_component<EndStop>("Endstop(X2 Min)", X2_MIN_PIN, !X2_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[1].position.x <= X2_MIN_POS; });
+      #else
+        root->add_component<EndStop>("Endstop(X2 Max)", X2_MAX_PIN, !X2_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[1].position.x >= X2_MAX_POS; });
+      #endif
+    #endif
+    #if Y_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Y Min)", Y_MIN_PIN, !Y_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y <= Y_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Y Max)", Y_MAX_PIN, !Y_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.y >= Y_MAX_POS; });
+    #endif
+    #if Z_HOME_DIR < 0
+      root->add_component<EndStop>("Endstop(Z Min)", Z_MIN_PIN, !Z_MIN_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z <= Z_MIN_POS; });
+    #else
+      root->add_component<EndStop>("Endstop(Z Max)", Z_MAX_PIN, !Z_MAX_ENDSTOP_HIT_STATE, [kinematics](){ return kinematics->state.effector_position[0].position.z >= Z_MAX_POS; });
+    #endif
   #endif
 
   auto print_bed = root->add_component<PrintBed>("Print Bed", glm::vec2{X_BED_SIZE, Y_BED_SIZE});

--- a/src/MarlinSimulator/visualisation.cpp
+++ b/src/MarlinSimulator/visualisation.cpp
@@ -123,6 +123,12 @@ void Visualisation::create() {
 
   auto kin = virtual_printer.get_component<KinematicSystem>("Cartesian Kinematic System");
   if(kin == nullptr) kin = virtual_printer.get_component<KinematicSystem>("Delta Kinematic System");
+  if(kin == nullptr) kin = virtual_printer.get_component<KinematicSystem>("CoreXY Kinematic System");
+  if(kin == nullptr) kin = virtual_printer.get_component<KinematicSystem>("CoreXZ Kinematic System");
+  if(kin == nullptr) kin = virtual_printer.get_component<KinematicSystem>("CoreYZ Kinematic System");
+  if(kin == nullptr) kin = virtual_printer.get_component<KinematicSystem>("CoreYX Kinematic System");
+  if(kin == nullptr) kin = virtual_printer.get_component<KinematicSystem>("CoreZX Kinematic System");
+  if(kin == nullptr) kin = virtual_printer.get_component<KinematicSystem>("CoreZY Kinematic System");
   if (kin != nullptr && kin->state.effector_position.size() == extrusion.size()) {
     size_t i = 0;
     for (auto state : kin->state.effector_position) {


### PR DESCRIPTION
Was wanting to look into a Marlin  issue on a COREXY machine, so added all the CORE's to the simulator 
Updated endstop UI so you can manually override their state
 
Updated SIM to automatically use min or max endstops as needed